### PR TITLE
Fix flaky test in SnippetsTests#group_elements_by_length

### DIFF
--- a/src/main/java/snippets/Snippets.java
+++ b/src/main/java/snippets/Snippets.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.LinkedHashMap;
 
 public abstract class Snippets {
 
@@ -305,7 +306,14 @@ public abstract class Snippets {
      * @return grouped elements in a Map
      */
     public static <T, R> Map<R, List<T>> groupBy(T[] elements, Function<T, R> func) {
-        return Arrays.stream(elements).collect(Collectors.groupingBy(func));
+        return Arrays.stream(elements).collect(
+		Collectors.groupingBy(
+			func,
+			LinkedHashMap::new,
+			Collectors.toList()
+		)
+	);
+
     }
 
     /**


### PR DESCRIPTION
This pull request fixes a flaky test in SnippetsTests#group_elements_by_length. The test would randomly fail because it used Collectors.groupingBy(func), which relies on HashMap and doesn’t keep the same order every time. Because of that, the expected and actual outputs sometimes had the same elements but in a different order when running with NonDex. To fix it, I updated the groupBy() method in Snippets.java to use a LinkedHashMap instead of a regular HashMap by changing the code to Collectors.groupingBy(func, LinkedHashMap::new, Collectors.toList()). This keeps the insertion order consistent and makes the test output stable. After making this change and running the test multiple times with NonDex, it passed every run, which shows the test is no longer flaky.